### PR TITLE
Support auto-provisioning of players

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ option](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview?_high
 | `HEADER_ROLES_SEPARATOR` | The symbol that is used to separate the roles in the header. | `,` |
 | `ROLE_PLAYER` | The role that marks someone as a player. | `role:foundry-vtt:player` |
 | `ROLE_ADMIN` | The role that marks someone as an admin. | `role:foundry-vtt:admin` |
+| `AUTO_PROVISION` | If set to `true`, players will be automatically created for users with the player role when they login.   | `false` |
 
 Check [the wiki](https://github.com/MaienM/foundry-vtt-header-auth/wiki) for more detailed (community-contributed) setup
 instructions.

--- a/patches.sh
+++ b/patches.sh
@@ -5,6 +5,7 @@ HEADER_ROLES="${HEADER_ROLES:-"x-auth-request-groups"}"
 HEADER_ROLES_SEPARATOR="${HEADER_ROLES_SEPARATOR:-","}"
 ROLE_PLAYER="${ROLE_PLAYER:-"role:foundry-vtt:player"}"
 ROLE_ADMIN="${ROLE_ADMIN:-"role:foundry-vtt:admin"}"
+AUTO_PROVISION="${AUTO_PROVISION:-"false"}"
 
 # usage: $0 patch-name file [sed-expression]
 # Utility to use sed to patch a file, verifying that it actually changed something.
@@ -174,3 +175,26 @@ patch_append hide-non-admin-setup resources/app/public/css/foundry2.css << END
 		margin-top: 0.5em;
 	}
 END
+
+# If enabled, create missing users with the PLAYER role when they login.
+if [ "$AUTO_PROVISION" = "true" ]; then
+	patch_append auto-provision-function resources/app/dist/server/views/join.mjs << END
+	async function _autoProvisionAndDumpUsers(session) {
+		const users = await db.User.dump();
+
+		if (session.headerInfo.isAdmin) {
+			return users;
+		}
+
+		const username = session.headerInfo.username.toLowerCase();
+		if (users.find((user) => user.name.toLowerCase() === username)) {
+			return users;
+		}
+
+		await db.User.create({name: username, role: 1});
+		return db.User.dump();
+	}
+END
+
+	patch_sed auto-provision-call-function resources/app/dist/server/views/join.mjs "s/users:await db\.User\.dump()/users:await _autoProvisionAndDumpUsers(s)/"
+fi


### PR DESCRIPTION
With `AUTO_PROVISION = true`, we will automatically create users with player roles for any non-admin who logs in and doesn't already have a user.

This allows one to manage users exclusively through whatever auth service they use.